### PR TITLE
fix(share-accepter): adding share accepter resource to create a nativ…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,9 +12,15 @@ resource "aws_ram_resource_association" "this" {
   resource_share_arn = aws_ram_resource_share.this.arn
 }
 
+# Add the accepter to ensure the share is active
+resource "aws_ram_resource_share_accepter" "this" {
+  share_arn = aws_ram_resource_share.this.arn
+}
+
 resource "aws_ram_principal_association" "this" {
   for_each = { for idx, principal in var.principals : idx => principal }
 
+  depends_on         = [aws_ram_resource_share_accepter.this]
   principal          = each.value
   resource_share_arn = aws_ram_resource_share.this.arn
 }


### PR DESCRIPTION
…e dependency

## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
Adds a new resource aws_ram_resource_share_accepter
## why

<!--
- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

The aws_ram_resource_share_accepter resource will wait for the share to be in an acceptable state before completing, which creates a proper dependency chain without requiring any external commands or sleep timers.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
